### PR TITLE
[HIVE] [serde] Fixed Flaky Test: org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe.testSerDeInnerNulls

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -557,6 +558,7 @@ public final class ObjectInspectorUtils {
    */
   public static Field[] getDeclaredNonStaticFields(Class<?> c) {
     Field[] f = c.getDeclaredFields();
+    Arrays.sort(f, Comparator.comparing(Field::getName));
     ArrayList<Field> af = new ArrayList<Field>();
     for (int i = 0; i < f.length; ++i) {
       if (!Modifier.isStatic(f[i].getModifiers())) {

--- a/serde/src/test/org/apache/hadoop/hive/serde2/columnar/TestLazyBinaryColumnarSerDe.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/columnar/TestLazyBinaryColumnarSerDe.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.serde2.columnar;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -234,7 +235,7 @@ public class TestLazyBinaryColumnarSerDe {
     outerStruct.mArray = new ArrayList<InnerStruct>(2);
     outerStruct.mArray.add(is1);
     outerStruct.mArray.add(is2);
-    outerStruct.mMap = new HashMap<String, InnerStruct>();
+    outerStruct.mMap = new LinkedHashMap<String, InnerStruct>();
     outerStruct.mMap.put(null, new InnerStruct(13, 14l));
     outerStruct.mMap.put(new String("fifteen"), null);
     outerStruct.mStruct = new InnerStruct(null, null);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This pull request fixes a Flaky Test *TestLazyBinaryColumnarSerDe#testSerDeInnerNulls* found by using the NonDex tool - https://github.com/TestingResearchIllinois/NonDex



1. Sorting the fields received in the field array after calling getDeclaredFields() by including the following statement 

```
{
Field[] f = c.getDeclaredFields();
+    Arrays.sort(f, Comparator.comparing(Field::getName));
}
```

2. The objects that were being serialized followed by deserialization contained a HashMap, the order of which was also being changed on deserialization & comparison. This was changed to a LinkedHashMap. 
```
{
-    outerStruct.mMap = new HashMap<String, InnerStruct>();
+    outerStruct.mMap = new LinkedHashMap<String, InnerStruct>();
}
```


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
**Error in NonDex (below and similar)** 
```
java.lang.ClassCastException: class java.lang.Float cannot be cast to class java.lang.Byte
```

**Analysis of the error**
The cause of the flaky test appears to be in 
*line 559: /hive/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java*
Here, there is a call to ```Field[] f = c.getDeclaredFields();``` 

```getDeclaredFields()``` states that *The elements in the array returned are not sorted and are not in any particular order.* 

Due to this reason, when the ObjectInspector is initialized in the 

``` 
{
    StructObjectInspector oi = (StructObjectInspector) ObjectInspectorFactory
        .getReflectionObjectInspector(OuterStruct.class, ObjectInspectorOptions.JAVA); 
}
```
call in the first line of the testcase, due to no fixed order, there is a mismatch in the Object and the ObjectInspector for a field. Hence when *seralize* is called in the function, this mismatch in types throws a *ClassCastException* error.

Further, the use of *HashMap* causes mismatch in order on serialization followed by deserialization. This is fixed by using a *LinkedHashMap*


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### Is the change a dependency upgrade?
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
No.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Tested using the NonDex tool (https://github.com/TestingResearchIllinois/NonDex).
